### PR TITLE
Default to --topo-order by default

### DIFF
--- a/git-forest
+++ b/git-forest
@@ -612,9 +612,8 @@ sub vis_xfrm
     }
   }
 
-	if ($Reverse_order) {
-		$s =~ tr/efg.rt.xyz/xyz.tr.efg/;
-	}
+
+  $s =~ tr/efg.xyz/xyz.efg/ if $Reverse_order;
 
   if ($Style == 1) {
     $s =~ tr/ABD.efg.IKm.xyz/├┤─.┌┬┐.│┼─.└┴┘/;

--- a/git-forest
+++ b/git-forest
@@ -15,8 +15,6 @@ use strict;
 use utf8;
 use Encode qw(encode);
 my $Repo          = Git->repository($ENV{"GIT_DIR"} || ".");
-my $No_print_refs = $ENV{"NO_PRINT_REFS"} || "false";
-# my $Pretty_fmt    = "format:%s";
 my $Pretty_fmt    = "format:%H\t%at\t%an\t%C(reset)%C(auto)%d%C(reset)\t%s";
 my $Reverse_order = 0;
 my $Show_all      = 0;
@@ -130,7 +128,6 @@ sub get_line_block
 sub process
 {
 	my(@vine);
-	my $refs = &get_refs();
 	my($fh, $fhc) = $Repo->command_output_pipe("log", "--parents", "--date-order",
 	                "--pretty=format:<%H><%h><%P>$Pretty_fmt", @ARGV);
 
@@ -147,15 +144,8 @@ sub process
 		&vine_branch(\@vine, $sha);
 		my $ra = &vine_commit(\@vine, $sha, \@parents);
 
-		if (exists($refs->{$sha})) {
-			print &vis_post(&vis_commit($ra),
-			      $Color{at}."m".$Color{default});
-			if ($No_print_refs ne "true") {
-				&ref_print($refs->{$sha});
-			}
-		} else {
-			print &vis_post(&vis_commit($ra, " "));
-		}
+		print &vis_post(&vis_commit($ra, " "));
+
 		if ($With_sha) {
 			print $msg, $Color{at}, encode('UTF-8', "──("), $Color{sha}, $mini_sha,
 			      $Color{at}, ")", $Color{default}, "\n";
@@ -166,104 +156,6 @@ sub process
 		&vine_merge(\@vine, $sha, \@next_sha, \@parents);
 	}
 	$Repo->command_close_pipe($fh, $fhc);
-}
-
-sub get_next_pick
-{
-	my $fh = shift @_;
-	while (defined(my $line = <$fh>)) {
-		if ($line =~ /^\s*#/) {
-			next;
-		}
-		if ($line =~ /^\S+\s+(\S+)/) {
-			return $2;
-		}
-	}
-	return undef;
-}
-
-sub get_refs
-{
-	my($fh, $c) = $Repo->command_output_pipe("show-ref");
-	my $ret = {};
-
-	while (defined(my $ln = <$fh>)) {
-		chomp $ln;
-		if (length($ln) == 0) {
-			next;
-		}
-
-		my($sha, $name) = ($ln =~ /^(\S+)\s+(.*)/s);
-		if (!exists($ret->{$sha})) {
-			$ret->{$sha} = [];
-		}
-		push(@{$ret->{$sha}}, $name);
-		if ($name =~ m{^refs/tags/}) {
-			my $sub_sha = $Repo->command("log", "-1",
-			              "--pretty=format:%H", $name);
-			chomp $sub_sha;
-			if ($sha ne $sub_sha) {
-				push(@{$ret->{$sub_sha}}, $name);
-			}
-		}
-	}
-
-	$Repo->command_close_pipe($fh, $c);
-
-	my $rebase = -e $Repo->repo_path()."/rebase-merge/git-rebase-todo" &&
-	             $Show_rebase;
-	if ($rebase) {
-		if (open(my $act_fh, $Repo->repo_path().
-		    "/rebase-merge/git-rebase-todo")) {
-			my($curr) = (<$act_fh> =~ /^\S+\s+(\S+)/);
-			$curr = &get_next_pick($act_fh);
-			if (defined($curr)) {
-				$curr = $Repo->command("rev-parse", $curr);
-				chomp $curr;
-				unshift(@{$ret->{$curr}}, "rebase/next");
-			}
-			close $act_fh;
-		}
-
-		chomp(my $onto = $Repo->command("rev-parse", "rebase-merge/onto"));
-		unshift(@{$ret->{$onto}}, "rebase/onto");
-	}
-
-	my $head = $Repo->command("rev-parse", "HEAD");
-	chomp $head;
-	if ($rebase) {
-		unshift(@{$ret->{$head}}, "rebase/new");
-	}
-	unshift(@{$ret->{$head}}, "HEAD");
-
-	return $ret;
-}
-
-#
-# ref_print - print a ref with color
-# @s:	ref name
-#
-sub ref_print
-{
-	foreach my $symbol (@{shift @_}) {
-		print $Color{at}, "[";
-		if ($symbol eq "HEAD" || $symbol =~ m{^rebase/}) {
-			print $Color{hhead}, $symbol;
-		} elsif ($symbol =~ m{^refs/remotes/([^/]+)/(.*)}s) {
-			if ($Color{remote} eq "") {
-				print "remotes/$1/$2";
-			} else {
-				print $Color{remote}, "$1/", $Color{head}, "$2";
-			}
-		} elsif ($symbol =~ m{^refs/heads/(.*)}s) {
-			print $Color{head}, $1;
-		} elsif ($symbol =~ m{^refs/tags/(.*)}s) {
-			print $Color{tag}, $1;
-		} elsif ($symbol =~ m{^refs/(.*)}s) {
-			print $Color{ref}, $1;
-		}
-		print $Color{at}, encode('UTF-8', "]──"), $Color{default};
-	}
 }
 
 #

--- a/git-forest
+++ b/git-forest
@@ -16,7 +16,8 @@ use utf8;
 use Encode qw(encode);
 my $Repo          = Git->repository($ENV{"GIT_DIR"} || ".");
 my $No_print_refs = $ENV{"NO_PRINT_REFS"} || "false";
-my $Pretty_fmt    = "format:%s";
+# my $Pretty_fmt    = "format:%s";
+my $Pretty_fmt    = "format:%H\t%at\t%an\t%C(reset)%C(auto)%d%C(reset)\t%s";
 my $Reverse_order = 0;
 my $Show_all      = 0;
 my $Show_rebase   = 1;
@@ -33,7 +34,34 @@ my %Color         = (
 	"sha"     => "\e[0;31m", # ]
 	"tag"     => "\e[1;33m", # ]
 	"tree"    => "\e[0;33m", # ]
+
+  "black"        => "\e[0;30m",
+  "red"          => "\e[0;31m",
+  "green"        => "\e[0;32m",
+  "yellow"       => "\e[0;33m",
+  "blue"         => "\e[0;34m",
+  "magenta"      => "\e[0;35m",
+  "cyan"         => "\e[0;36m",
+  "white"        => "\e[0;37m",
+
+  "black_bold"   => "\e[1;30m",
+  "red_bold"     => "\e[1;31m",
+  "green_bold"   => "\e[1;32m",
+  "yellow_bold"  => "\e[1;33m",
+  "blue_bold"    => "\e[1;34m",
+  "magenta_bold" => "\e[1;35m",
+  "cyan_bold"    => "\e[1;36m",
+  "white_bold"   => "\e[1;37m",
 );
+my @Branch_colors_ref     = ('blue_bold', 'yellow_bold', 'magenta_bold', 'green_bold', 'cyan_bold');
+my @Branch_colors_now     = ();
+
+my $Graph_symbol_commit   = '●';
+my $Graph_symbol_merge    = '◎';
+my $Graph_symbol_overpass = '═';
+my $Graph_symbol_root     = '■';
+my $Graph_symbol_tip      = '○';
+my $Graph_symbol_tr;
 
 &main();
 
@@ -42,7 +70,7 @@ sub main
 	&Getopt::Long::Configure(qw(bundling pass_through));
 	&GetOptions(
 		"all"       => \$Show_all,
-		"no-color"  => sub { %Color = (); },
+		# "no-color"  => sub { %Color = (); },
 		"no-rebase" => sub { $Show_rebase = 0; },
 		"a"         => sub { $Pretty_fmt = "format:\e[1;30m(\e[0;32m%an\e[1;30m)\e[0m %s"; }, # ]]]]
 		"pretty=s"  => \$Pretty_fmt,
@@ -51,6 +79,7 @@ sub main
 		"style=i"   => \$Style,
 		"sha"       => \$With_sha,
 	);
+  $Graph_symbol_tr = trgen();
 	++$Subvine_depth;
 	if (substr($Pretty_fmt, 0, 7) ne "format:") {
 		die "If you use --pretty, it must be in the form of --pretty=format:";
@@ -564,20 +593,39 @@ sub vis_xfrm
 		}esg;
 	}
 
+  # Change Branch colors
+  my @s_arr_orig = split //, $s;
+  my $i = 0;
+  my @s_arr_odd = grep { $i++ % 2 == 0 } @s_arr_orig;
+
+  for my $i (0 .. $#s_arr_odd) {
+    if ($s_arr_odd[$i] =~ /^[efgt]$/) {
+      my $j = -1;
+      while ($j <= $#Branch_colors_ref) {
+        $j++;
+        next if $i > 0 && $Branch_colors_now[$i - 1] eq $Branch_colors_ref[$j];
+        next if $Branch_colors_now[$i] eq $Branch_colors_ref[$j];
+        next if $i < $#s_arr_odd && $Branch_colors_now[$i + 1] eq $Branch_colors_ref[$j];
+        last;
+      }
+      $Branch_colors_now[$i] = $Branch_colors_ref[$j];
+    }
+  }
+
 	if ($Reverse_order) {
 		$s =~ tr/efg.rt.xyz/xyz.tr.efg/;
 	}
 
-	if ($Style == 1) {
-		$s =~ tr/ABCD.efg.IKO.mrt.xyz/├┤├─.┌┬┐.│┼≡.─└┌.└┴┘/;
-	} elsif ($Style == 2) {
-		$s =~ tr/ABCD.efg.IKO.mrt.xyz/╠╣╟═.╔╦╗.║╬═.─╙╓.╚╩╝/;
-	} elsif ($Style == 10) {
-		$s =~ tr/ABCD.efg.IKO.mrt.xyz/├┤├─.╭┬╮.│┼≡.─└┌.╰┴╯/;
-	} elsif ($Style == 15) {
-		$s =~ tr/ABCD.efg.IKO.mrt.xyz/┣┫┣━.┏┳┓.┃╋☰.━┗┏.┗┻┛/;
-	}
-	return $s;
+  if ($Style == 1) {
+    $s =~ tr/ABD.efg.IKm.xyz/├┤─.┌┬┐.│┼─.└┴┘/;
+  } elsif ($Style == 2) {
+    $s =~ tr/ABD.efg.IKm.xyz/╠╣═.╔╦╗.║╬─.╚╩╝/;
+  } elsif ($Style == 10) {
+    $s =~ tr/ABD.efg.IKm.xyz/├┤─.╭┬╮.│┼─.╰┴╯/;
+  } elsif ($Style == 15) {
+    $s =~ tr/ABD.efg.IKm.xyz/┣┫━.┏┳┓.┃╋━.┗┻┛/;
+  }
+  return $Graph_symbol_tr->($s);
 }
 
 #
@@ -598,6 +646,10 @@ sub vis_post
 		$s .= $f;
 	}
 
+  if ($s =~ /^(.*)([$Graph_symbol_commit$Graph_symbol_merge$Graph_symbol_root$Graph_symbol_tip])/) {
+    my $branch_color = $Color{$Branch_colors_now[length($1) / 2]};
+    $s =~ s/([$Graph_symbol_commit$Graph_symbol_merge$Graph_symbol_root$Graph_symbol_tip])/$branch_color$1$Color{tree}/;
+  }
 	return $Color{tree}, encode('UTF-8', $s), $Color{default};
 }
 
@@ -629,6 +681,14 @@ sub str_expand
 	}
 }
 
+sub trgen {
+  eval qq(sub {
+    my \$s = shift;
+    \$s =~ tr/CMOrt/$Graph_symbol_commit$Graph_symbol_merge$Graph_symbol_overpass$Graph_symbol_root$Graph_symbol_tip/;
+    return \$s;
+  });
+}
+
 package ReverseOutput;
 require Tie::Handle;
 @ReverseOutput::ISA = qw(Tie::Handle);
@@ -649,6 +709,13 @@ sub PRINT
 	my $fh   = $self->{fh};
 
 	$self->{saved} .= join($\, @_);
+}
+
+sub PRINTF
+{
+  my $self = shift;
+  my $format = shift;
+  $self->{saved} .= sprintf($format, @_);
 }
 
 sub UNTIE

--- a/git-forest
+++ b/git-forest
@@ -128,7 +128,7 @@ sub get_line_block
 sub process
 {
 	my(@vine);
-	my($fh, $fhc) = $Repo->command_output_pipe("log", "--parents", "--date-order",
+	my($fh, $fhc) = $Repo->command_output_pipe("log", "--parents", "--topo-order",
 	                "--pretty=format:<%H><%h><%P>$Pretty_fmt", @ARGV);
 
 	while (my($line, @next_sha) = get_line_block($fh, $Subvine_depth)) {

--- a/git-forest
+++ b/git-forest
@@ -131,7 +131,7 @@ sub process
 {
 	my(@vine);
 	my $refs = &get_refs();
-	my($fh, $fhc) = $Repo->command_output_pipe("log", "--date-order",
+	my($fh, $fhc) = $Repo->command_output_pipe("log", "--parents", "--date-order",
 	                "--pretty=format:<%H><%h><%P>$Pretty_fmt", @ARGV);
 
 	while (my($line, @next_sha) = get_line_block($fh, $Subvine_depth)) {


### PR DESCRIPTION
Changed to --date-order in c060ee81d0961f20a38d7ac7d8e4669aaec51974

The commit indicates that "--topo-order" can override "--date-order".
However, the inverse is also true.

Topographic order is the default for "git log --graph". Seeing the two
commands produce different output is confusing.

While "--date-order" can seem more intuitive, it does not always produce
the best results.

Git codebase history with --topo-order:

```
┌ 2021-12-22 [2ae0a9cb82] {Junio C Hamano} (HEAD -> master, origin/master, origin/main, origin/HEAD) The fifth batch
├ 2021-12-22 [d52da62801] {Junio C Hamano} Merge branch 'es/chainlint'
├─┐
│ ├ 2021-12-13 [d73f5cfa89] {Eric Sunshine} chainlint.sed: stop splitting "(..." into separate lines "(" and "..."
│ ├ 2021-12-13 [31da22d1fd] {Eric Sunshine} chainlint.sed: swallow comments consistently
│ ├ 2021-12-13 [34ba05c296] {Eric Sunshine} chainlint.sed: stop throwing away here-doc tags
│ ├ 2021-12-13 [22597af97d] {Eric Sunshine} chainlint.sed: don't mistake `<< word` in string as here-doc operator
│ ├ 2021-12-13 [2d53614210] {Eric Sunshine} chainlint.sed: make here-doc "<<-" operator recognition more POSIX-like
│ ├ 2021-12-13 [5be30d0cd3] {Eric Sunshine} chainlint.sed: drop subshell-closing ">" annotation
│ ├ 2021-12-13 [0d7131763e] {Eric Sunshine} chainlint.sed: drop unnecessary distinction between ?!AMP?! and ?!SEMI?!
```

Git codebase history with --date-order:

```
┌ 2021-12-22 [2ae0a9cb82] {Junio C Hamano} (HEAD -> master, origin/master, origin/main, origin/HEAD) The fifth batch
├ 2021-12-22 [d52da62801] {Junio C Hamano} Merge branch 'es/chainlint'
├─┐
├ │ 2021-12-22 [62a3a27b91] {Junio C Hamano} Merge branch 'jz/apply-quiet-and-allow-empty'
├─≡─┐
├ │ │ 2021-12-22 [5536415551] {Junio C Hamano} Merge branch 'jk/limit-developers-to-gnu99'
├─≡≡≡─┐
├ │ │ │ 2021-12-22 [67b7017593] {Junio C Hamano} Merge branch 'ab/common-main-cleanup'
├─≡≡≡≡≡─┐
├ │ │ │ │ 2021-12-22 [dcaf17c75d] {Junio C Hamano} Merge branch 'ab/fetch-set-upstream-while-detached'
├─≡≡≡≡≡≡≡─┐
├ │ │ │ │ │ 2021-12-21 [597af311a2] {Junio C Hamano} The fourth batch
├ │ │ │ │ │ 2021-12-21 [62e83d4f69] {Junio C Hamano} Merge branch 'js/scalar'
├─≡≡≡≡≡≡≡≡≡─┐
├ │ │ │ │ │ │ 2021-12-21 [8d2c37320b] {Junio C Hamano} Merge branch 'ld/sparse-diff-blame'
├─≡≡≡≡≡≡≡≡≡≡≡─┐
```